### PR TITLE
Render photos from database for random restaurant on load/refresh to photo banner

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -2,14 +2,32 @@ import React from 'react';
 import styled from 'styled-components';
 import SaveThisRestaurantButton from './SaveThisRestaurantButton';
 import PhotoBanner from './PhotoBanner';
-import fakeImageData from '../../fakeImgData';
+import ajax from '../lib/ajax';
+// import fakeImageData from '../../fakeImgData';
 
 class App extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      photos: fakeImageData,
+      photos: [],
     };
+  }
+
+  componentDidMount() {
+    const randomId = Math.floor(Math.random() * 100);
+    this.getPhotosForBanner(randomId);
+  }
+
+  getPhotosForBanner(id) {
+    ajax.getPhotos(id, (err, data) => {
+      if (err) {
+        console.log(err);
+        return;
+      }
+      this.setState({
+        photos: data,
+      });
+    });
   }
 
   render() {
@@ -17,9 +35,9 @@ class App extends React.Component {
     return (
       <div>
         <NavPlaceholder />
-        <div className="topBanner">
+        <MainBannerDiv>
           <PhotoBanner photos={photos} />
-        </div>
+        </MainBannerDiv>
         <SaveThisRestaurantButton>Save This Restaurant</SaveThisRestaurantButton>
         <OverviewPlaceholder />
         <h2>50 Photos</h2>
@@ -39,4 +57,8 @@ const OverviewPlaceholder = styled.div`
 const NavPlaceholder = styled.div`
   height: 10rem;
   background: url(https://via.placeholder.com/1300x177?text=Restaurant+NavBar+Placeholder);
+`;
+
+const MainBannerDiv = styled.div`
+  margin: 10px;
 `;

--- a/client/src/components/Photo.jsx
+++ b/client/src/components/Photo.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 const Photo = props => (
   <ImgSpan>
-    <Img src={props.photo} alt="" />
+    <Img src={props.photo.image_url} alt="" />
   </ImgSpan>
 );
 
@@ -11,7 +11,7 @@ export default Photo;
 
 const Img = styled.img`
   display: inline-block;
-  border: 2px solid gray;
+  border: 3px solid gray;
   transition: all .2s ease-out;
 `;
 

--- a/client/src/components/Photo.jsx
+++ b/client/src/components/Photo.jsx
@@ -2,15 +2,23 @@ import React from 'react';
 import styled from 'styled-components';
 
 const Photo = props => (
-  <span>
-    <SpanImg src={props.photo} alt="" />
-  </span>
+  <ImgSpan>
+    <Img src={props.photo} alt="" />
+  </ImgSpan>
 );
 
 export default Photo;
 
-const SpanImg = styled.img`
+const Img = styled.img`
   display: inline-block;
   border: 2px solid gray;
   transition: all .2s ease-out;
+`;
+
+const ImgSpan = styled.span`
+  ${Img}: hover {
+    transform: scale(1.05);
+    opacity: 1;
+    cursor: pointer;
+  }
 `;

--- a/client/src/components/PhotoBanner.jsx
+++ b/client/src/components/PhotoBanner.jsx
@@ -35,13 +35,14 @@ const PhotoInnerDiv = styled.div`
   display: block;
   width: 200%;
   margin: auto;
+  padding: .75em;
   position: relative;
-  animation: ${scroll} 20s linear infinite;
+  animation: ${scroll} 30s linear infinite;
 `;
 
 const PhotoDiv = styled.div`
   display: inline-block;
-  height: 288px;
+  height: 19em;
   width: 100%;
   border: 2px solid #eee;
   overflow: hidden;

--- a/client/src/components/PhotoBanner.jsx
+++ b/client/src/components/PhotoBanner.jsx
@@ -48,6 +48,9 @@ const PhotoDiv = styled.div`
   box-sizing: border-box;
   position: relative;
   margin: auto;
+  ${PhotoInnerDiv}: hover {
+    animation-play-state: paused;
+  }
 `;
 
 export default PhotoBanner;

--- a/client/src/components/PhotoBanner.jsx
+++ b/client/src/components/PhotoBanner.jsx
@@ -16,7 +16,7 @@ class PhotoBanner extends React.Component {
       <PhotoDiv>
         <PhotoInnerDiv>
           {this.props.photos.map(photo => (
-            <Photo photo={photo} />
+            <Photo photo={photo} key={photo.id} />
           ))}
         </PhotoInnerDiv>
       </PhotoDiv>
@@ -36,15 +36,14 @@ const PhotoInnerDiv = styled.div`
   width: 200%;
   margin: auto;
   padding: .75em;
-  position: relative;
+  position: absolute;
   animation: ${scroll} 30s linear infinite;
 `;
 
 const PhotoDiv = styled.div`
   display: inline-block;
-  height: 19em;
+  height: 19.53em;
   width: 100%;
-  border: 2px solid #eee;
   overflow: hidden;
   box-sizing: border-box;
   position: relative;

--- a/client/src/lib/ajax.js
+++ b/client/src/lib/ajax.js
@@ -1,16 +1,13 @@
 import $ from 'jquery';
 
 export default {
-  getPhotos: (id) => {
+  getPhotos: (id, callback) => {
     $.get({
       url: `http://localhost:8888/api/photos/${id}`,
-      success: (data) => {
-        return data;
-      },
+      success: data => callback(null, data),
       error: (err) => {
-        console.log('Failed to retrieve photos due to: ', err);
-      }
+        callback(err);
+      },
     });
-  }
+  },
 };
-


### PR DESCRIPTION
On refresh, the photo banner on the top of the page will have a specific photo for that specific restaurant scrolling across the top of the page. If you hover over the banner, it will pause the banner from auto-scrolling. When you hover over the specific photo, it will zoom in on the photo a little bit. 