### PR TITLE
Add Key event listeners on Photo Modal and for accurate photo to appear on modal

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -1,18 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
-import { library } from '@fortawesome/fontawesome-svg-core';
-import {
-  faAngleRight, faAngleLeft, faTimes,
-} from '@fortawesome/free-solid-svg-icons';
 import SaveThisRestaurantButton from './SaveThisRestaurantButton';
 import PhotoBanner from './PhotoBanner';
 import PhotoModal from './PhotoModal';
 import PhotoDisplay from './PhotoDisplay';
 import ajax from '../lib/ajax';
-
-library.add(faAngleRight);
-library.add(faAngleLeft);
-library.add(faTimes);
 
 class App extends React.Component {
   constructor(props) {

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -22,6 +22,7 @@ class App extends React.Component {
       randomId: Math.floor(Math.random() * 100) + 1,
       displayPhoto: 'none',
       displayFlag: 'none',
+      clickedImageIndex: 0,
     };
     this.openPhotoModal = this.openPhotoModal.bind(this);
     this.closePhotoModal = this.closePhotoModal.bind(this);
@@ -45,9 +46,10 @@ class App extends React.Component {
     });
   }
 
-  openPhotoModal() {
+  openPhotoModal(event) {
     this.setState({
       displayPhoto: 'block',
+      clickedImageIndex: parseInt(event.target.dataset.indexNumber),
     });
   }
 
@@ -57,9 +59,10 @@ class App extends React.Component {
     });
   }
 
-  openFlagModal() {
+  openFlagModal(index) {
     this.setState({
       displayFlag: 'block',
+      clickedImageIndex: index,
     });
   }
 
@@ -71,7 +74,7 @@ class App extends React.Component {
 
   render() {
     const {
-      photos, randomId, displayPhoto, displayFlag,
+      photos, randomId, displayPhoto, displayFlag, clickedImageIndex,
     } = this.state;
 
     return (
@@ -96,7 +99,7 @@ class App extends React.Component {
             <PhotoDisplay photos={photos} openModal={this.openPhotoModal} closeModal={this.closePhotoModal} />
           </Display>
         </PhotoContainer>
-        <PhotoModal randomId={randomId} photos={photos} closeModal={this.closePhotoModal} openFlag={this.openFlagModal} closeFlag={this.closeFlagModal} displayPhoto={displayPhoto} displayFlag={displayFlag} />
+        <PhotoModal randomId={randomId} photos={photos} closeModal={this.closePhotoModal} openFlag={this.openFlagModal} closeFlag={this.closeFlagModal} displayPhoto={displayPhoto} displayFlag={displayFlag} clickedImageIndex={clickedImageIndex} />
       </div>
     );
   }

--- a/client/src/components/Photo.jsx
+++ b/client/src/components/Photo.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 const Photo = props => (
   <ImgSpan>
-    <Img onClick={event => props.openModal(event)} src={props.photo.image_url} alt="" />
+    <Img data-index-number={props.index} onClick={event => props.openModal(event)} src={props.photo.image_url} alt="" />
   </ImgSpan>
 );
 
@@ -13,7 +13,6 @@ const Img = styled.img`
   width: 18em;
   display: inline-block;
   border: 3px solid #2d333f;
-  transition: all .2s ease-out;
 `;
 
 const ImgSpan = styled.span`

--- a/client/src/components/PhotoBanner.jsx
+++ b/client/src/components/PhotoBanner.jsx
@@ -7,8 +7,8 @@ const PhotoBanner = (props) => {
   return (
     <PhotoDiv>
       <PhotoInnerDiv>
-        {photos.map(photo => (
-          <Photo photo={photo} key={photo.id} openModal={openModal} closeModal={closeModal} />
+        {photos.map((photo, i) => (
+          <Photo photo={photo} key={photo.id} index={i} openModal={openModal} closeModal={closeModal} />
         ))}
       </PhotoInnerDiv>
     </PhotoDiv>

--- a/client/src/components/PhotoCarousel.jsx
+++ b/client/src/components/PhotoCarousel.jsx
@@ -4,7 +4,7 @@ import FlagModal from './FlagModal';
 
 const PhotoCarousel = (props) => {
   const {
-    url, caption, date, username, openFlag, closeFlag, displayFlag, imageIndex
+    url, caption, date, username, openFlag, closeFlag, displayFlag, imageIndex,
   } = props;
   return (
     <div>

--- a/client/src/components/PhotoCarousel.jsx
+++ b/client/src/components/PhotoCarousel.jsx
@@ -4,7 +4,7 @@ import FlagModal from './FlagModal';
 
 const PhotoCarousel = (props) => {
   const {
-    url, caption, date, username, openFlag, closeFlag, displayFlag,
+    url, caption, date, username, openFlag, closeFlag, displayFlag, imageIndex
   } = props;
   return (
     <div>
@@ -27,7 +27,7 @@ const PhotoCarousel = (props) => {
             <Username>{username}</Username>
           </div>
         </span>
-        <FlagSpan onClick={event => openFlag(event)}>
+        <FlagSpan onClick={() => openFlag(imageIndex)}>
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
             <path id="_24._Tiny_Flag_Icon" fill="#fff" d="M485,475H469v12h-2V463h18l-3,6Zm-16-10v8h13l-2-4,2-4H469Z" transform="translate(-464 -463)" />
           </svg>

--- a/client/src/components/PhotoCarouselLeftArrow.jsx
+++ b/client/src/components/PhotoCarouselLeftArrow.jsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const PhotoCarouselLeftArrow = ({ imageIndex, prevImg }) => {
   const arrowColor = imageIndex === 0 ? '#333333' : '#91949a';
 
   return (
     <LeftArrowDiv>
-      <FontAwesomeIcon onClick={prevImg} icon="angle-left" style={{ color: arrowColor }} />
+      <LeftArrow onClick={prevImg} style={{ color: arrowColor }} />
     </LeftArrowDiv>
   );
 };
@@ -16,13 +15,21 @@ const LeftArrowDiv = styled.div`
   &:hover {
     color: #6f737b;
   }
-  font-size: 2em;
   position: absolute;
   top: 50%;
   left: 0;
-  font-family: icons;
-  font-style: normal;
   outline: none;
+  cursor: pointer;
+`;
+
+const LeftArrow = styled.i`
+  border: solid;
+  border-width: 0 2px 2px 0;
+  display: inline-block;
+  padding: 3px;
+  transform: rotate(135deg);
+  height: 5px;
+  width: 5px;
 `;
 
 export default PhotoCarouselLeftArrow;

--- a/client/src/components/PhotoCarouselLeftArrow.jsx
+++ b/client/src/components/PhotoCarouselLeftArrow.jsx
@@ -2,14 +2,17 @@ import React from 'react';
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-const PhotoCarouselLeftArrow = props => (
-  <LeftArrowDiv>
-    <FontAwesomeIcon onClick={props.prevImg} icon="angle-left" />
-  </LeftArrowDiv>
-);
+const PhotoCarouselLeftArrow = ({ imageIndex, prevImg }) => {
+  const arrowColor = imageIndex === 0 ? '#333333' : '#91949a';
+
+  return (
+    <LeftArrowDiv>
+      <FontAwesomeIcon onClick={prevImg} icon="angle-left" style={{ color: arrowColor }} />
+    </LeftArrowDiv>
+  );
+};
 
 const LeftArrowDiv = styled.div`
-  color: #91949a;
   &:hover {
     color: #6f737b;
   }

--- a/client/src/components/PhotoCarouselRightArrow.jsx
+++ b/client/src/components/PhotoCarouselRightArrow.jsx
@@ -2,11 +2,15 @@ import React from 'react';
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-const PhotoCarouselRightArrow = props => (
-  <RightArrowDiv>
-    <FontAwesomeIcon onClick={props.nextImg} icon="angle-right" />
-  </RightArrowDiv>
-);
+const PhotoCarouselRightArrow = ({ imageIndex, images, nextImg }) => {
+  const arrowColor = imageIndex === images.length - 1 ? '#333333' : '#91949a';
+
+  return (
+    <RightArrowDiv>
+      <FontAwesomeIcon onClick={nextImg} icon="angle-right" style={{ color: arrowColor }} />
+    </RightArrowDiv>
+  );
+};
 
 const RightArrowDiv = styled.div`
   color: #91949a;

--- a/client/src/components/PhotoCarouselRightArrow.jsx
+++ b/client/src/components/PhotoCarouselRightArrow.jsx
@@ -1,29 +1,35 @@
 import React from 'react';
 import styled from 'styled-components';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const PhotoCarouselRightArrow = ({ imageIndex, images, nextImg }) => {
   const arrowColor = imageIndex === images.length - 1 ? '#333333' : '#91949a';
 
   return (
     <RightArrowDiv>
-      <FontAwesomeIcon onClick={nextImg} icon="angle-right" style={{ color: arrowColor }} />
+      <RightArrow onClick={nextImg} style={{ color: arrowColor }} />
     </RightArrowDiv>
   );
 };
 
 const RightArrowDiv = styled.div`
-  color: #91949a;
   &:hover {
     color: #6f737b;
   }
-  font-size: 2em;
   position: absolute;
   top: 50%;
   right: 0;
-  font-family: icons;
-  font-style: normal;
   outline: none;
+  cursor: pointer;
+`;
+
+const RightArrow = styled.i`
+  border: solid;
+  border-width: 0 2px 2px 0;
+  display: inline-block;
+  padding: 3px;
+  transform: rotate(-45deg);
+  height: 5px;
+  width: 5px;
 `;
 
 export default PhotoCarouselRightArrow;

--- a/client/src/components/PhotoDisplayEntry.jsx
+++ b/client/src/components/PhotoDisplayEntry.jsx
@@ -1,40 +1,46 @@
 import React from 'react';
 import styled from 'styled-components';
+import { inherits } from 'util';
 
 const PhotoDisplayEntry = props => (
   <ImgContainer>
     <span>
       <div>
-        <MediumImg onClick={event => props.openModal(event)} src={props.photos[0].image_url} alt="" />
+        <MediumImg data-index-number="0" onClick={event => props.openModal(event)} src={props.photos[0].image_url} alt="" />
       </div>
       <div>
-        <MediumImg onClick={event => props.openModal(event)} src={props.photos[1].image_url} alt="" />
-      </div>
-    </span>
-    <span>
-      <LargeImg onClick={event => props.openModal(event)} src={props.photos[2].image_url} alt="" />
-    </span>
-    <span>
-      <div>
-        <SmallImg onClick={event => props.openModal(event)} src={props.photos[3].image_url} alt="" />
-      </div>
-      <div>
-        <SmallImg onClick={event => props.openModal(event)} src={props.photos[4].image_url} alt="" />
-      </div>
-      <div>
-        <SmallImg onClick={event => props.openModal(event)} src={props.photos[5].image_url} alt="" />
+        <MediumImg data-index-number="1" onClick={event => props.openModal(event)} src={props.photos[1].image_url} alt="" />
       </div>
     </span>
     <span>
+      <LargeImg data-index-number="2" onClick={event => props.openModal(event)} src={props.photos[2].image_url} alt="" />
+    </span>
+    <span>
       <div>
-        <SmallImg onClick={event => props.openModal(event)} src={props.photos[6].image_url} alt="" />
+        <SmallImg data-index-number="3" onClick={event => props.openModal(event)} src={props.photos[3].image_url} alt="" />
       </div>
       <div>
-        <SmallImg onClick={event => props.openModal(event)} src={props.photos[7].image_url} alt="" />
+        <SmallImg data-index-number="4" onClick={event => props.openModal(event)} src={props.photos[4].image_url} alt="" />
       </div>
       <div>
-        <LastSmallImg onClick={event => props.openModal(event)} src={props.photos[8].image_url} alt="" />
-        <LastSmallOverlay onClick={event => props.openModal(event)}>
+        <SmallImg data-index-number="5" onClick={event => props.openModal(event)} src={props.photos[5].image_url} alt="" />
+      </div>
+    </span>
+    <span>
+      <div>
+        <SmallImg data-index-number="6" onClick={event => props.openModal(event)} src={props.photos[6].image_url} alt="" />
+      </div>
+      <div>
+        <SmallImg data-index-number="7" onClick={event => props.openModal(event)} src={props.photos[7].image_url} alt="" />
+      </div>
+      <div>
+        <LastSmallOverlay>
+          <LastSmallImg
+            data-index-number="8"
+            onClick={event => props.openModal(event)}
+            src={props.photos[8].image_url}
+            alt=""
+          />
           <TextDiv>
             +
             {' '}
@@ -76,31 +82,32 @@ const SmallImg = styled.img`
 `;
 
 const LastSmallImg = styled.img`
+  position: absolute;
   height: 90.84px;
   width: 90.84px;
   margin: 0 2px;
-  z-index: -1;
-  position: absolute;
+  opacity: .4;
+  cursor: pointer;
+  &:hover {
+    opacity: .7
+  }
 `;
 
 const LastSmallOverlay = styled.div`
-  background-color: rgba(0, 0, 0, 0.6);
   position: absolute;
   height: 90.84px;
   width: 90.84px;
   margin: 0 2px;
-  cursor: pointer;
-  z-index: 0;
-  &:hover {
-    background-color: rgba(0, 0, 0, 0.8)
-  };
 `;
 
 const TextDiv = styled.div`
   position: absolute;
   top: 40%;
-  left: 20%;
-  font-size: 12px;
+  left: 18%;
+  font-size: 13px;
+  font-weight: 500;
   font-family: BrandonText,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
-  color: white;
+  color: rgba(255, 255, 255, 255);
+  text-shadow: 1px 1px #a6a6a6;
+  cursor: pointer;
 `;

--- a/client/src/components/PhotoModal.jsx
+++ b/client/src/components/PhotoModal.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import moment from 'moment';
 import PhotoCarousel from './PhotoCarousel';
 import PhotoCarouselRightArrow from './PhotoCarouselRightArrow';
@@ -98,9 +97,9 @@ class PhotoModal extends React.Component {
           </Wrapper>
         </InnerModal>
 
-        <ExitButton>
-          <FontAwesomeIcon type="button" onClick={closeModal} icon="times" />
-        </ExitButton>
+        <ExitButtonDiv>
+          <ExitButton onClick={closeModal} href="#" />
+        </ExitButtonDiv>
       </ModalPhotoDiv>
     );
   }
@@ -126,19 +125,41 @@ const ModalPhotoDiv = styled.div`
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.85);
+  background: rgba(0, 0, 0, 0.9);
 `;
 
-const ExitButton = styled.div`
-  color: #6f737b;
-  font-size: 2em;
+const ExitButtonDiv = styled.div`
   position: absolute;
-  top: 2%;
-  right: 2%;
-  font-family: icons;
-  font-style: normal;
-  font-weight: normal;
+  top: 1%;
+  right: 1%;
   outline: none;
+  cursor: pointer;
+`;
+
+const ExitButton = styled.a`
+  position: absolute;
+  right: 32px;
+  top: 32px;
+  width: 15px;
+  height: 15px;
+  &:before {
+    position: absolute;
+    left: 15px;
+    content: ' ';
+    height: 25px;
+    width: 2px;
+    background-color: #6f737b;
+    transform: rotate(45deg);
+  }
+  &:after {
+    position: absolute;
+    left: 15px;
+    content: ' ';
+    height: 25px;
+    width: 2px;
+    background-color: #6f737b;
+    transform: rotate(-45deg);
+  }
 `;
 
 export default PhotoModal;

--- a/client/src/components/PhotoModal.jsx
+++ b/client/src/components/PhotoModal.jsx
@@ -26,14 +26,15 @@ class PhotoModal extends React.Component {
     document.addEventListener('keyup', this.handleKeyPress);
   }
 
-  componentWillUnmount() {
-    document.removeEventListener('keyup', this.handleKeyPress);
-  }
 
   componentWillReceiveProps(nextProps) {
     this.setState({
-      currentImageIndex: nextProps.clickedImageIndex
-    })
+      currentImageIndex: nextProps.clickedImageIndex,
+    });
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keyup', this.handleKeyPress);
   }
 
   getImagesForBanner(id) {
@@ -91,9 +92,9 @@ class PhotoModal extends React.Component {
       <ModalPhotoDiv style={{ display: displayPhoto }}>
         <InnerModal>
           <Wrapper>
-            <PhotoCarouselLeftArrow prevImg={this.handlePreviousImageClick} />
+            <PhotoCarouselLeftArrow prevImg={this.handlePreviousImageClick} imageIndex={currentImageIndex} />
             <PhotoCarousel openFlag={openFlag} closeFlag={closeFlag} displayFlag={displayFlag} url={images[currentImageIndex].image_url} caption={images[currentImageIndex].caption} username={images[currentImageIndex].username} date={moment(images[currentImageIndex].date_posted).format('LL')} imageIndex={currentImageIndex} />
-            <PhotoCarouselRightArrow nextImg={this.handleNextImageClick} />
+            <PhotoCarouselRightArrow nextImg={this.handleNextImageClick} imageIndex={currentImageIndex} images={images} />
           </Wrapper>
         </InnerModal>
 

--- a/client/src/components/PhotoModal.jsx
+++ b/client/src/components/PhotoModal.jsx
@@ -12,7 +12,7 @@ class PhotoModal extends React.Component {
     super(props);
     this.state = {
       images: [{}],
-      currentImageIndex: 0,
+      currentImageIndex: this.props.clickedImageIndex,
       randomId: this.props.randomId,
       currentKey: '',
     };
@@ -28,6 +28,12 @@ class PhotoModal extends React.Component {
 
   componentWillUnmount() {
     document.removeEventListener('keyup', this.handleKeyPress);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      currentImageIndex: nextProps.clickedImageIndex
+    })
   }
 
   getImagesForBanner(id) {
@@ -86,7 +92,7 @@ class PhotoModal extends React.Component {
         <InnerModal>
           <Wrapper>
             <PhotoCarouselLeftArrow prevImg={this.handlePreviousImageClick} />
-            <PhotoCarousel openFlag={openFlag} closeFlag={closeFlag} displayFlag={displayFlag} url={images[currentImageIndex].image_url} caption={images[currentImageIndex].caption} username={images[currentImageIndex].username} date={moment(images[currentImageIndex].date_posted).format('LL')} />
+            <PhotoCarousel openFlag={openFlag} closeFlag={closeFlag} displayFlag={displayFlag} url={images[currentImageIndex].image_url} caption={images[currentImageIndex].caption} username={images[currentImageIndex].username} date={moment(images[currentImageIndex].date_posted).format('LL')} imageIndex={currentImageIndex} />
             <PhotoCarouselRightArrow nextImg={this.handleNextImageClick} />
           </Wrapper>
         </InnerModal>

--- a/client/src/components/PhotoModal.jsx
+++ b/client/src/components/PhotoModal.jsx
@@ -14,13 +14,20 @@ class PhotoModal extends React.Component {
       images: [{}],
       currentImageIndex: 0,
       randomId: this.props.randomId,
+      currentKey: '',
     };
     this.handlePreviousImageClick = this.handlePreviousImageClick.bind(this);
     this.handleNextImageClick = this.handleNextImageClick.bind(this);
+    this.handleKeyPress = this.handleKeyPress.bind(this);
   }
 
   componentDidMount() {
     this.getImagesForBanner(this.state.randomId);
+    document.addEventListener('keyup', this.handleKeyPress);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keyup', this.handleKeyPress);
   }
 
   getImagesForBanner(id) {
@@ -51,6 +58,21 @@ class PhotoModal extends React.Component {
     this.setState({
       currentImageIndex: currentImageIndex !== images.length - 1 ? currentImageIndex + 1 : images.length - 1,
     });
+  }
+
+  handleKeyPress(event) {
+    event.preventDefault();
+    this.setState({
+      currentKey: event.keyCode,
+    });
+    const { currentKey } = this.state;
+    if (currentKey === 39) {
+      this.handleNextImageClick(event);
+    } else if (currentKey === 37) {
+      this.handlePreviousImageClick(event);
+    } else if (currentKey === 27) {
+      this.props.closeModal();
+    }
   }
 
   render() {


### PR DESCRIPTION
1) Updated the PhotoModal to have key listeners: 
    a) When the "esc" key is pressed, you can exit the modal
    b) When the "-->" arrow key is pressed, it goes to the next image
    c) When the <--" arrow key is pressed, it goes to the previous image
2) When you click on a photo on the photo banner, that actual photo pops up in the modal now
3) Fixed the bug that I noticed regarding the flag modal that pops up. The original bug was that when I clicked on the flag icon, it would open up the flag modal. After I closed the flag modal and moved on to a different photo, I clicked on the flag icon again. it would open up the flag modal but it would jump back to the original photo where the flag modal first popped up on.